### PR TITLE
Fixes for 261

### DIFF
--- a/app/controllers/kpm/nodes_info_controller.rb
+++ b/app/controllers/kpm/nodes_info_controller.rb
@@ -8,6 +8,8 @@ module KPM
     include ActionController::Live
 
     def index
+      @installing = !params[:i].blank?
+
       @nodes_info = ::KillBillClient::Model::NodesInfo.nodes_info(options_for_klient)
 
       # For convenience, put pure OSGI bundles at the bottom
@@ -76,7 +78,7 @@ module KPM
 
     def install_plugin
       trigger_node_plugin_command('INSTALL_PLUGIN')
-      redirect_to :action => :index
+      redirect_to nodes_info_index_path(:i => 1)
     end
 
     def uninstall_plugin

--- a/app/views/kpm/nodes_info/index.html.erb
+++ b/app/views/kpm/nodes_info/index.html.erb
@@ -3,6 +3,7 @@
   <div class="column-block">
 
     <h1>Configured instances
+      <div id="install-in-progress" class="btn btn-xs text-success" style="display: none;"><i class="fa fa-refresh"></i>&nbsp;Operation in progress</div>
       <%= link_to('<i class="fa fa-refresh"></i>&nbsp;Operation complete, reload page'.html_safe, url_for, :id => "reload-page", :class => 'btn btn-xs text-success', :style => "display: none;") %>
       <% if kpm_plugin_installed?(@nodes_info) %>
         <div class="pull-right">
@@ -46,7 +47,22 @@
       setTimeout(fakeOperationComplete, 6000);
     });
 
+    <%- if @installing %>
+      // Prevent other clicks
+      $('.plugin-link').removeAttr('data-remote')
+                       .removeAttr('data-method')
+                       .removeAttr('href')
+      $('#nodes-table-wrapper').css({ opacity: 0.5 });
+
+      $('#install-in-progress').show();
+      $('#install-in-progress').children().addClass('fa-spin');
+
+      setTimeout(fakeOperationComplete, 6000);
+    <% end %>
+
     function fakeOperationComplete() {
+      $('#install-in-progress').hide();
+
       $('.plugin-link').children().removeClass('fa-spin');
       $('#nodes-table-wrapper').fadeTo("slow", 0.5);
       $('#reload-page').fadeIn("slow");

--- a/app/views/kpm/plugins/_form.html.erb
+++ b/app/views/kpm/plugins/_form.html.erb
@@ -2,7 +2,7 @@
     <div class="form-group">
       <%= label_tag :plugin_key, 'Plugin key', :class => 'col-sm-2 control-label' %>
       <div class="col-sm-9">
-        <%= text_field_tag :plugin_key, '', :class => 'form-control', :placeholder => 'Plugin key', :required => true %>
+        <%= text_field_tag :plugin_key, '', :class => 'form-control', :placeholder => 'Unique identifier for this plugin, e.g. myCompany:myPluginName', :required => true %>
       </div>
     </div>
     <div class="form-group">
@@ -14,7 +14,7 @@
     <div class="form-group">
       <%= label_tag :plugin_uri, 'URI', :class => 'col-sm-2 control-label' %>
       <div class="col-sm-9">
-        <%= text_field_tag :plugin_uri, '', :class => 'form-control', :placeholder => 'Plugin URI', :required => true %>
+        <%= text_field_tag :plugin_uri, '', :class => 'form-control', :placeholder => 'HTTP(S) url accessible from all Kill Bill nodes', :required => true %>
       </div>
     </div>
     <div class='form-group'>


### PR DESCRIPTION
See https://github.com/killbill/killbill-admin-ui/issues/261:

> After installing a new plugin the "configured instances" section does not refresh (and no indication that we should refresh) -> NOK

The UI doesn't have today an easy way to detect the installation is done on all nodes. I've added a little animation to prompt the user to refresh after a little bit.

> The Upload Plugin screen with the custom URI needs some sane default values (what is a valid URI ?, what is a valid key ?). For the URI, it seems we only support scheme 'http', 'https', 'ws', or 'wss'.

See f6b7fe30d224c32a57185b6c90bf9c6e795e31dd.

> I could not install the payment-test-plugin.

The payment-test-plugin doesn't respect our convention to use `org.kill-bill.billing.plugin.java` as the `groupId` for our plugins: https://github.com/killbill/killbill-payment-test-plugin/blob/cb7d1065a10ba838ff4c3c7937512183123ed2f7/pom.xml#L13 Thus, it won't work with our cloud directory.

I did try https://github.com/killbill/killbill-cloud/commit/5eacd500919f4a2f2eef285a3fee04a8a91c7f4d as a workaround, but it doesn't work with the KPM bundle due to internal validations (not worth pursuing IMHO, it's easier to fix the plugin and re-release):

```
Aborting installation for plugin_key payment-test: specified value org.kill-bill.billing.plugin.java for group_id does not match looked_up value org.killbill.billing.plugin.payment
./kpm/lib/kpm/base_installer.rb:261:in `validate_installation_arg!'
./kpm/lib/kpm/base_installer.rb:88:in `install_plugin'
./kpm/lib/kpm/tasks.rb:164:in `install_java_plugin'
```

> Should we also support a file scheme -- or we enforce to have a webserver?

We cannot support a file scheme, as the installation process is run on each Kill Bill node (the URL is passed to each node, which will each download the plugin locally).

The previous version of Kaui (for 0.20.x) did support a file scheme but it only worked on a single node installation when Kill Bill and Kaui were running on the same machine. I've dropped support for this when migrating to the KPM bundle (sounded marginally useful - it's much easier to copy the jar then to upload it via Kaui when developing locally anyways).
