### PR TITLE
Rename killbill-assest-ui to killbill_assets_ui

### DIFF
--- a/lib/kpm/engine.rb
+++ b/lib/kpm/engine.rb
@@ -8,7 +8,7 @@
 # See also https://github.com/carlhuda/bundler/issues/49
 
 require 'killbill_client'
-require 'killbill-assets-ui'
+require 'killbill_assets_ui'
 
 module KPM
   class Engine < ::Rails::Engine


### PR DESCRIPTION
Rename killbill-assest-ui to killbill_assets_ui.
Related PR: https://github.com/killbill/killbill-assets-ui/pull/8/files